### PR TITLE
Add react cog for introductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ The bot uses a YAML configuration file (`config.yaml`) to control various settin
     The ID of the channel used for forwarding direct messages.
   - `games_channel_id`:  
     The ID of the channel for games night announcements.
-  - `gigchats_id`:  
+  - `gigchats_id`:
     The ID of the channel used for gig chats forum updates.
-  - `welcome_channel_id`:  
+  - `welcome_channel_id`:
     The ID of the channel where welcome messages are posted.
+  - `introductions_channel_id`:
+    The ID of the channel where the bot reacts to introduction messages.
 
 - **Role Settings:**
   - `newjoin_role_id`:  

--- a/cogs/react.py
+++ b/cogs/react.py
@@ -1,0 +1,63 @@
+import discord
+import logging
+import yaml
+from discord.ext import commands
+import datetime
+
+
+def audit_log(message: str):
+    """Append a timestamped message to the audit log file."""
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with open("audit.log", "a", encoding="utf-8") as f:
+        f.write(f"[{timestamp}] {message}\n")
+
+
+class React(commands.Cog):
+    """Automatically reacts to introduction messages."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        # Load config with UTF-8 encoding for emoji support
+        with open("config.yaml", "r", encoding="utf-8") as config_file:
+            self.config = yaml.safe_load(config_file)
+        # Channel where the bot should react to introductions
+        self.introductions_channel_id = self.config.get("introductions_channel_id")
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        logging.info("\033[96mReact\033[0m cog synced successfully.")
+        audit_log("React cog synced successfully.")
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        # Ignore messages sent by bots
+        if message.author.bot:
+            return
+
+        # Ensure the channel matches the configured introductions channel
+        if not self.introductions_channel_id:
+            return
+        if message.channel.id != self.introductions_channel_id:
+            return
+
+        # React when message contains the required phrase
+        if "🏹Name:" in message.content:
+            try:
+                await message.add_reaction("👋")
+                logging.info(
+                    f"Reacted to message {message.id} in #{message.channel.name}"
+                )
+                audit_log(
+                    f"Reacted with 👋 to message {message.id} in channel #{message.channel.name} (ID: {message.channel.id}) in guild '{message.guild.name}' (ID: {message.guild.id})."
+                )
+            except discord.HTTPException as e:
+                logging.error(
+                    f"Failed to react to message {message.id} in #{message.channel.name}: {e}"
+                )
+                audit_log(
+                    f"Error reacting to message {message.id} in channel #{message.channel.name} (ID: {message.channel.id}): {e}"
+                )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(React(bot))

--- a/config - dev server.yaml
+++ b/config - dev server.yaml
@@ -40,6 +40,7 @@ games_channel_id: 1281260171754082430     # Channel for sending games night anno
 gigchats_id: 1302737683537334332           # Channel for gig chats forum.
 welcome_channel_id: 1346179245923106907    # Channel where welcome messages are posted.
 new_member_channel_id: 1346179590795559047        # Channel where new members are directed.
+introductions_channel_id: 0                       # Channel for introduction messages.
 
 # --------------------------
 # Role Settings

--- a/config - the parlour.yaml
+++ b/config - the parlour.yaml
@@ -40,6 +40,7 @@ games_channel_id: 1159782202985426964         # Channel for sending games night 
 gigchats_id: 1195097407604666399               # Channel for gig chats forum.
 welcome_channel_id: 1151864993571160135        # Channel where welcome messages are posted.
 new_member_channel_id: 1174309687324315679        # Channel where new members are directed.
+introductions_channel_id: 0                       # Channel for introduction messages.
 
 # --------------------------
 # Role Settings

--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,7 @@ games_channel_id: 1159782202985426964         # Channel for sending games night 
 gigchats_id: 1195097407604666399               # Channel for gig chats forum.
 welcome_channel_id: 1151864993571160135        # Channel where welcome messages are posted.
 new_member_channel_id: 1174309687324315679        # Channel where new members are directed.
+introductions_channel_id: 0                       # Channel for introduction messages.
 
 # --------------------------
 # Role Settings


### PR DESCRIPTION
## Summary
- add new `React` cog to react with a wave emoji when members introduce themselves
- document new `introductions_channel_id` config option
- include channel ID setting in all configuration files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68794fb49884832ea83f5fdfd32b2de1